### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/treemana/code-snippet-go/security/code-scanning/1](https://github.com/treemana/code-snippet-go/security/code-scanning/1)

To fix the problem, we add an explicit `permissions` block, limiting the GitHub Actions workflow’s access to the repository via its GITHUB_TOKEN to read-only contents. Since the workflow only performs code checkout, builds, and tests (no deployment or pull request manipulation), it does not require any write permissions. Add the following YAML block right after the `name: Go` entry and before `on:` at the root of the workflow file to apply it to all jobs unless otherwise specified. No changes to steps or jobs are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
